### PR TITLE
Handler validation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -26,8 +26,10 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -67,6 +69,8 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
             "tsconfig.es.json", "tsconfig.es.json",
             "tsconfig.json", "tsconfig.json"
     );
+    private static final ShapeId VALIDATION_EXCEPTION_SHAPE =
+            ShapeId.fromParts("smithy.framework", "ValidationException");
 
     private final TypeScriptSettings settings;
     private final Model model;
@@ -201,6 +205,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         IndexGenerator.writeIndex(settings, model, symbolProvider, fileManifest, integrations, protocolGenerator);
 
         if (settings.generateServerSdk()) {
+            checkValidationSettings();
             // Generate index for server
             IndexGenerator.writeServerIndex(settings, model, symbolProvider, fileManifest);
         }
@@ -221,6 +226,28 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         LOGGER.fine("Generating package.json files");
         PackageJsonGenerator.writePackageJson(
                 settings, fileManifest, SymbolDependency.gatherDependencies(dependencies.stream()));
+    }
+
+    private void checkValidationSettings() {
+        if (settings.isDisableDefaultValidation()) {
+            return;
+        }
+
+        List<String> unvalidatedOperations = model.getOperationShapes()
+                .stream()
+                .filter(o -> !o.getErrors().contains(VALIDATION_EXCEPTION_SHAPE))
+                .map(s -> s.getId().toString())
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (!unvalidatedOperations.isEmpty()) {
+            throw new CodegenException(String.format("Every operation must have the %s error attached unless %s is set "
+                    + "to 'true' in the plugin settings. Operations without %s errors attached: %s",
+                    VALIDATION_EXCEPTION_SHAPE,
+                    TypeScriptSettings.DISABLE_DEFAULT_VALIDATION,
+                    VALIDATION_EXCEPTION_SHAPE,
+                    unvalidatedOperations));
+        }
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -98,10 +98,21 @@ final class ServerCommandGenerator implements Runnable {
             } else {
                 writeStreamingMemberType(writer, symbolProvider.toSymbol(input), typeName, blobStreamingMembers.get(0));
             }
+            renderNamespace(typeName, input);
         } else {
             // If the input is non-existent, then use an empty object.
             writer.write("export interface $L {}", typeName);
         }
+    }
+
+    private void renderNamespace(String typeName, StructureShape input) {
+        Symbol symbol = symbolProvider.toSymbol(input);
+        writer.openBlock("export namespace $L {", "}", typeName, () -> {
+            writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
+            writer.writeDocs("@internal");
+            writer.write("export const validate: (obj: $L) => __ValidationFailure[] = $T.validate;",
+                    symbol.getName(), symbol);
+        });
     }
 
     private void writeOutputType(String typeName, Optional<StructureShape> outputShape) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import static software.amazon.smithy.typescript.codegen.TypeScriptDependency.SERVER_COMMON;
+
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.ReservedWordSymbolProvider;
 import software.amazon.smithy.codegen.core.ReservedWords;
@@ -97,7 +99,7 @@ final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements 
         String moduleName = moduleNameDelegator.formatModuleName(shape, serviceName);
 
         Symbol intermediate = createGeneratedSymbolBuilder(shape, serviceName, moduleName).build();
-        Symbol.Builder builder = intermediate.toBuilder();
+        Symbol.Builder builder = intermediate.toBuilder().addDependency(SERVER_COMMON);
         builder.putProperty("operations",
                 intermediate.toBuilder().name(serviceName + "Operations").build());
         builder.putProperty("handler",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -214,6 +214,7 @@ final class StructureGenerator implements Runnable {
             structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
             writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
+            writer.writeDocs("@internal");
             writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
                     objectParam, symbol.getName(),
                     () -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -78,7 +78,10 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     // Conditionally added when XML parser needs to be used.
     XML_PARSER("dependencies", "fast-xml-parser", "3.19.0", false),
-    HTML_ENTITIES("dependencies", "entities", "2.2.0", false);
+    HTML_ENTITIES("dependencies", "entities", "2.2.0", false),
+
+    // Server dependency for SSDKs
+    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "^1.0.0-alpha.0", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -270,6 +270,7 @@ final class UnionGenerator implements Runnable {
         structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
         writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
+        writer.writeDocs("@internal");
         writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
                 "obj", symbol.getName(),
                 () -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -337,25 +337,47 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.addImport("serializeFrameworkException", null,
                 "./protocols/" + ProtocolGenerator.getSanitizedName(getName()));
+        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
 
         Symbol serviceSymbol = symbolProvider.toSymbol(context.getService());
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
         Symbol operationsSymbol = serviceSymbol.expectProperty("operations", Symbol.class);
 
-        writer.openBlock("export const get$L = (service: $T): __ServiceHandler => {", "}",
-                handlerSymbol.getName(), serviceSymbol, () -> {
-            generateServiceMux(context);
-            writer.addImport("SmithyException", "__SmithyException", "@aws-sdk/smithy-client");
-            writer.openBlock("const serFn: (op: $1T) => __OperationSerializer<$2T, $1T, __SmithyException> = "
-                            + "(op) => {", "};", operationsSymbol, serviceSymbol, () -> {
-                writer.openBlock("switch (op) {", "}", () -> {
-                    operations.stream()
-                            .filter(o -> o.getTrait(HttpTrait.class).isPresent())
-                            .forEach(writeOperationCase(writer, symbolProvider));
-                });
+        if (context.getSettings().isDisableDefaultValidation()) {
+            writer.write("export const get$L = (service: $T, "
+                            + "customizer: __ValidationCustomizer<$T>): __ServiceHandler => {",
+                    handlerSymbol.getName(), serviceSymbol, operationsSymbol);
+        } else {
+            writer.write("export const get$L = (service: $T): __ServiceHandler => {",
+                    handlerSymbol.getName(), serviceSymbol);
+        }
+        writer.indent();
+
+        generateServiceMux(context);
+        writer.addImport("SmithyException", "__SmithyException", "@aws-sdk/smithy-client");
+        writer.openBlock("const serFn: (op: $1T) => __OperationSerializer<$2T, $1T, __SmithyException> = "
+                        + "(op) => {", "};", operationsSymbol, serviceSymbol, () -> {
+            writer.openBlock("switch (op) {", "}", () -> {
+                operations.stream()
+                        .filter(o -> o.getTrait(HttpTrait.class).isPresent())
+                        .forEach(writeOperationCase(writer, symbolProvider));
             });
-            writer.write("return new $T(service, mux, serFn, serializeFrameworkException);", handlerSymbol);
         });
+
+        if (!context.getSettings().isDisableDefaultValidation()) {
+            writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
+            writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
+            writer.openBlock("const customizer: __ValidationCustomizer<$T> = (ctx, failures) => {", "};",
+                operationsSymbol,
+                () -> {
+                    writeDefaultValidationCustomizer(writer);
+                }
+            );
+        }
+
+        writer.write("return new $T(service, mux, serFn, serializeFrameworkException, customizer);", handlerSymbol);
+
+        writer.dedent().write("}");
     }
 
     @Override
@@ -372,13 +394,48 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         final Symbol serializerType = operationSymbol.expectProperty("serializerType", Symbol.class);
         final Symbol operationHandlerSymbol = operationSymbol.expectProperty("handler", Symbol.class);
 
-        writer.openBlock("export const get$L = (operation: __Operation<$T, $T>): __ServiceHandler => {", "}",
-                operationHandlerSymbol.getName(), inputType, outputType,
+        if (context.getSettings().isDisableDefaultValidation()) {
+            writer.write("export const get$L = (operation: __Operation<$T, $T>, "
+                            + "customizer: __ValidationCustomizer<$S>): __ServiceHandler => {",
+                    operationHandlerSymbol.getName(), inputType, outputType, operation.getId().getName());
+        } else {
+            writer.write("export const get$L = (operation: __Operation<$T, $T>): __ServiceHandler => {",
+                    operationHandlerSymbol.getName(), inputType, outputType);
+        }
+        writer.indent();
+
+        generateOperationMux(context, operation);
+
+        if (!context.getSettings().isDisableDefaultValidation()) {
+            writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
+            writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
+            writer.openBlock("const customizer: __ValidationCustomizer<$S> = (ctx, failures) => {", "};",
+                operation.getId().getName(),
                 () -> {
-                    generateOperationMux(context, operation);
-                    writer.write("return new $T(operation, mux, new $T(), serializeFrameworkException);",
-                            operationHandlerSymbol, serializerType);
-                });
+                    writeDefaultValidationCustomizer(writer);
+                }
+            );
+        }
+        writer.write("return new $T(operation, mux, new $T(), serializeFrameworkException, customizer);",
+                operationHandlerSymbol, serializerType);
+
+        writer.dedent().write("}");
+    }
+
+    private void writeDefaultValidationCustomizer(TypeScriptWriter writer) {
+        writer.openBlock("if (!failures) {", "}", () -> {
+            writer.write("return undefined;");
+        });
+
+        writer.openBlock("return {", "};", () -> {
+            writer.write("name: \"ValidationException\",");
+            writer.write("$$fault: \"client\",");
+            writer.write("message: __generateValidationSummary(failures),");
+            writer.openBlock("fieldList: failures.map(failure => ({", "}))", () -> {
+                writer.write("member: failure.memberName,");
+                writer.write("message: __generateValidationMessage(failure)");
+            });
+        });
     }
 
     private Consumer<OperationShape> writeOperationCase(

--- a/smithy-typescript-integ-tests/.eslintrc.js
+++ b/smithy-typescript-integ-tests/.eslintrc.js
@@ -1,0 +1,30 @@
+module.exports = {
+  parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+  parserOptions: {
+    ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
+    sourceType: "module", // Allows for the use of imports
+  },
+  extends: [
+    // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    "plugin:@typescript-eslint/recommended",
+  ],
+  plugins: ["@typescript-eslint", "simple-import-sort"],
+  rules: {
+    /** Turn off strict enforcement */
+    "@typescript-eslint/ban-types": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "prefer-rest-params": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+
+    /** Warnings */
+    "@typescript-eslint/no-namespace": "warn",
+
+    /** Errors */
+    "simple-import-sort/imports": "error",
+  },
+};

--- a/smithy-typescript-integ-tests/codegen/build.gradle
+++ b/smithy-typescript-integ-tests/codegen/build.gradle
@@ -23,7 +23,8 @@ buildscript {
     dependencies {
         classpath 'software.amazon.smithy.typescript:smithy-typescript-codegen:0.3.0'
         classpath 'software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.3.0'
-        classpath "software.amazon.smithy:smithy-model:1.7.2"
+        classpath "software.amazon.smithy:smithy-model:1.8.0"
+        classpath "software.amazon.smithy:smithy-validation:1.8.0"
     }
 }
 
@@ -32,7 +33,7 @@ plugins {
 }
 
 dependencies {
-    implementation "software.amazon.smithy:smithy-aws-traits:1.7.2"
+    implementation "software.amazon.smithy:smithy-aws-traits:1.8.0"
 }
 
 repositories {

--- a/smithy-typescript-integ-tests/codegen/custom_validation/custom_validation.smithy
+++ b/smithy-typescript-integ-tests/codegen/custom_validation/custom_validation.smithy
@@ -1,0 +1,38 @@
+namespace software.amazon.smithy.typescript.integ
+
+use aws.protocols#restJson1
+
+@restJson1
+service CustomValidation {
+    version: "2020-01-25",
+    operations: [Test]
+}
+
+@readonly
+@http(method: "POST", uri:"/test")
+operation Test {
+    input: TestInput,
+    errors: [CustomValidationError]
+}
+
+structure TestInput {
+    enumList: ListOfEnums
+}
+
+@enum([{"value" : "valueA"}, {"value": "valueB"}])
+string Enum
+
+@length(max: 2)
+list ListOfEnums {
+    member: Enum
+}
+
+@error("client")
+structure CustomValidationError {
+    failingMembers: StringList,
+    totalFailures: Integer
+}
+
+list StringList {
+    member: String
+}

--- a/smithy-typescript-integ-tests/codegen/smithy-build.json
+++ b/smithy-typescript-integ-tests/codegen/smithy-build.json
@@ -2,11 +2,22 @@
   "version": "1.0",
   "outputDirectory": "build/output",
   "projections": {
-    "ts-server": {
+    "validation": {
+      "imports": ["validation"],
       "plugins": {
         "typescript-ssdk-codegen": {
           "package": "@aws-smithy/typescript-integ-test-types",
           "packageVersion": "1.0.0"
+        }
+      }
+    },
+    "customValidation": {
+      "imports": ["custom_validation"],
+      "plugins": {
+        "typescript-ssdk-codegen": {
+          "package": "@aws-smithy/typescript-integ-test-custom-validation",
+          "packageVersion": "1.0.0",
+          "disableDefaultValidation": true
         }
       }
     }

--- a/smithy-typescript-integ-tests/codegen/validation/validation.smithy
+++ b/smithy-typescript-integ-tests/codegen/validation/validation.smithy
@@ -11,7 +11,8 @@ service ValidationService {
 @readonly
 @http(method: "POST", uri:"/test")
 operation Test {
-    input: TestInput
+    input: TestInput,
+    errors: [ smithy.framework#ValidationException ]
 }
 
 structure TestInput {

--- a/smithy-typescript-integ-tests/package.json
+++ b/smithy-typescript-integ-tests/package.json
@@ -6,12 +6,19 @@
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "clean": "yarn clear-build-cache && yarn clear-build-info",
+    "clear-build-cache": "rimraf ./*/dist ./*/types, ./*/*.tgz",
+    "clear-build-info": "rimraf **/*.tsbuildinfo",
     "prepublishOnly": "yarn build",
-    "pretest": "yarn generate && yarn build:generated && yarn build",
-    "generate": "cd codegen && gradle build",
-    "build:generated": "cd codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen && yarn install && yarn link @aws-smithy/server-common && yarn build",
+    "pretest": "yarn build",
+    "generate": "cd codegen && gradle clean build",
+    "build:validation": "cd codegen/build/smithyprojections/codegen/validation/typescript-ssdk-codegen && yarn install && yarn link @aws-smithy/server-common && yarn build",
+    "build:customValidation": "cd codegen/build/smithyprojections/codegen/customValidation/typescript-ssdk-codegen && yarn install && yarn link @aws-smithy/server-common && yarn build",
+    "build:generated": "yarn build:validation && yarn build:customValidation",
     "build": "tsc -p tsconfig.json",
-    "test": "jest"
+    "test": "jest",
+    "lint": "yarn run eslint **/src/**/*.ts",
+    "format": "prettier --write **/*.{ts,js,json}"
   },
   "repository": {
     "type": "git",
@@ -27,7 +34,16 @@
     "jest": "^26.6.3",
     "ts-jest": "^26.5.2",
     "typescript": "^4.2.2",
-    "@aws-smithy/typescript-integ-test-types": "1.0.0"
+    "@aws-smithy/typescript-integ-test-types": "1.0.0",
+    "@aws-smithy/typescript-integ-test-custom-validation": "1.0.0",
+    "prettier": "2.2.1",
+    "eslint": "7.14.0",
+    "eslint-config-prettier": "6.15.0",
+    "eslint-plugin-prettier": "3.1.4",
+    "eslint-plugin-simple-import-sort": "6.0.1",
+    "@typescript-eslint/eslint-plugin": "4.22.1",
+    "@typescript-eslint/parser": "4.22.1",
+    "rimraf": "^3.0.2"
   },
   "engines": {
     "node": ">= 14.0.0"
@@ -37,6 +53,7 @@
   },
   "homepage": "https://github.com/awslabs/smithy-typescript#readme",
   "workspaces": [
-    "codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen"
+    "codegen/build/smithyprojections/codegen/validation/typescript-ssdk-codegen",
+    "codegen/build/smithyprojections/codegen/customValidation/typescript-ssdk-codegen"
   ]
 }

--- a/smithy-typescript-integ-tests/prettier.config.js
+++ b/smithy-typescript-integ-tests/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // Custom
+  printWidth: 120,
+};

--- a/smithy-typescript-integ-tests/src/custom_validation.spec.ts
+++ b/smithy-typescript-integ-tests/src/custom_validation.spec.ts
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { ValidationContext, ValidationFailure } from "@aws-smithy/server-common";
+import {
+  CustomValidationError,
+  CustomValidationErrorError,
+  getTestHandler,
+} from "@aws-smithy/typescript-integ-test-custom-validation";
+import { Readable } from "stream";
+
+const testHandler = getTestHandler(
+  async () => {
+    return { $metadata: {} };
+  },
+  (context: ValidationContext<"Test">, failures: ValidationFailure[]): CustomValidationError | undefined => {
+    if (!failures) {
+      return undefined;
+    }
+    return new CustomValidationErrorError({
+      failingMembers: Array.from(new Set(failures.map((f) => f.memberName))),
+      totalFailures: failures.length,
+    });
+  }
+);
+
+describe("custom validation", () => {
+  it("does not fail valid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enum": "valueA"}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(200);
+      });
+  });
+  it("fails invalid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enumList": ["BANG!", "POW!", "valueA"]}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(400);
+        expect(result.headers["x-amzn-errortype"]).toEqual("CustomValidationError");
+        const parsedBody = JSON.parse(result.body);
+        expect(parsedBody.failingMembers).toEqual(["enumList"]);
+        expect(parsedBody.totalFailures).toEqual(3);
+      });
+  });
+});

--- a/smithy-typescript-integ-tests/src/default_validation.spec.ts
+++ b/smithy-typescript-integ-tests/src/default_validation.spec.ts
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { getTestHandler } from "@aws-smithy/typescript-integ-test-types";
+import { Readable } from "stream";
+
+const testHandler = getTestHandler(async () => {
+  return { $metadata: {} };
+});
+
+describe("automatic validation", () => {
+  it("does not fail valid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enum": "valueA"}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(200);
+      });
+  });
+  it("fails invalid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enum": "BANG!"}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(400);
+        expect(result.headers["x-amzn-errortype"]).toEqual("ValidationException");
+        const parsedBody = JSON.parse(result.body);
+        expect(parsedBody.message).toContain("1 validation error detected");
+        expect(parsedBody.fieldList).toHaveLength(1);
+        expect(parsedBody.fieldList[0].member).toEqual("enum");
+        expect(parsedBody.fieldList[0].message).toEqual(
+          "Value BANG! failed to satisfy constraint: Member must satisfy enum value set: valueA,valueB"
+        );
+      });
+  });
+});

--- a/smithy-typescript-integ-tests/src/enum.spec.ts
+++ b/smithy-typescript-integ-tests/src/enum.spec.ts
@@ -13,11 +13,11 @@
  *  permissions and limitations under the License.
  */
 
-import { TestInput, Enum } from "@aws-smithy/typescript-integ-test-types";
+import { Enum, TestInput } from "@aws-smithy/typescript-integ-test-types";
 
 describe("enum constraints", () => {
   const validEnum: Enum = "valueA";
-  const invalidEnum: string = "invalidEnum";
+  const invalidEnum = "invalidEnum";
   const expectedFailureBase = {
     constraintType: "enum",
     constraintValues: ["valueA", "valueB"],

--- a/smithy-typescript-integ-tests/src/length.spec.ts
+++ b/smithy-typescript-integ-tests/src/length.spec.ts
@@ -17,9 +17,7 @@ import { LengthTests } from "@aws-smithy/typescript-integ-test-types";
 
 describe("length constraints", () => {
   it("work for strings", () => {
-    expect(
-      LengthTests.validate({ minMaxLengthString: "much longer than 7" })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthString: "much longer than 7" })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 7],
@@ -59,9 +57,7 @@ describe("length constraints", () => {
     ]);
   });
   it("also work on map keys", () => {
-    expect(
-      LengthTests.validate({ minMaxLengthMap: { a: 1, bcd: 2, cde: 3 } })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthMap: { a: 1, bcd: 2, cde: 3 } })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 7],
@@ -105,9 +101,7 @@ describe("length constraints", () => {
     ]);
   });
   it("also work on list values", () => {
-    expect(
-      LengthTests.validate({ minMaxLengthList: ["abcdefghijk", "def"] })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthList: ["abcdefghijk", "def"] })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 7],
@@ -125,9 +119,7 @@ describe("length constraints", () => {
         memberName: "minMaxLengthBlob",
       },
     ]);
-    expect(
-      LengthTests.validate({ minMaxLengthBlob: Buffer.of(1, 2, 3, 4, 5) })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthBlob: Buffer.of(1, 2, 3, 4, 5) })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 4],

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -13,6 +13,8 @@
  *  permissions and limitations under the License.
  */
 
+import { SmithyException } from "@aws-sdk/smithy-client";
+
 export * from "./validators";
 
 interface StandardValidationFailure<ConstraintBoundsType, FailureType> {
@@ -46,7 +48,7 @@ export interface RangeValidationFailure extends StandardValidationFailure<number
 
 export class RequiredValidationFailure {
   memberName: string;
-  constraintType = "required";
+  constraintType: "required" = "required";
 
   constructor(memberName: string) {
     this.memberName = memberName;
@@ -66,3 +68,83 @@ export type ValidationFailure =
   | RangeValidationFailure
   | RequiredValidationFailure
   | UniqueItemsValidationFailure;
+
+export interface ValidationContext<O extends string> {
+  operation: O;
+}
+
+export type ValidationCustomizer<O extends string> = (
+  context: ValidationContext<O>,
+  failures: ValidationFailure[]
+) => SmithyException | undefined;
+
+export const generateValidationSummary = (failures: readonly ValidationFailure[]): string => {
+  let failingMembers = new Set(failures.map((failure) => failure.memberName));
+
+  var message = `${failures.length} validation error${failures.length > 1 ? "s" : ""} `;
+
+  if (failures.length > 1) {
+    message += `across ${failingMembers.size} ` + `member${failingMembers.size > 1 ? "s" : ""} `;
+  }
+
+  message += `detected. `;
+
+  message += `Member '${failures[0].memberName}' failed: ${generateValidationMessage(failures[0])}.`;
+
+  return message;
+};
+
+export const generateValidationMessage = (failure: ValidationFailure): string => {
+  let failureValue = failure.constraintType === "required" ? "null" : failure.failureValue.toString();
+
+  let prefix: string;
+  let suffix: string;
+  switch (failure.constraintType) {
+    case "required": {
+      prefix = "Value";
+      suffix = "must not be null";
+      break;
+    }
+    case "enum": {
+      prefix = "Value";
+      suffix = `must satisfy enum value set: ${failure.constraintValues}`;
+      break;
+    }
+    case "length": {
+      prefix = "Value with length";
+      let min = failure.constraintValues[0];
+      let max = failure.constraintValues[1];
+      if (min === undefined) {
+        suffix = `must have length less than or equal to ${max}`;
+      } else if (max === undefined) {
+        suffix = `must have length greater than or equal to ${min}`;
+      } else {
+        suffix = `must have length between ${min} and ${max}, inclusive`;
+      }
+      break;
+    }
+    case "pattern": {
+      prefix = "Value";
+      suffix = `must satisfy regular expression pattern: ${failure.constraintValues}`;
+      break;
+    }
+    case "range": {
+      prefix = "Value";
+      let min = failure.constraintValues[0];
+      let max = failure.constraintValues[1];
+      if (min === undefined) {
+        suffix = `must be less than or equal to ${max}`;
+      } else if (max === undefined) {
+        suffix = `must be greater than or equal to ${min}`;
+      } else {
+        suffix = `must be between ${min} and ${max}, inclusive`;
+      }
+      break;
+    }
+    case "uniqueItems": {
+      prefix = "Value with repeated values";
+      suffix = "must have unique values";
+    }
+  }
+  return `${prefix} ${failureValue} failed to satisfy constraint: Member ${suffix}`;
+};


### PR DESCRIPTION
*Description of changes:*

Basing this on my fork for now, since my previous PR is still outstanding against awslabs.

The gist of this change is this: if you add `smithy.framework#ValidationException` to every operation, we will generate
code that turns validation failures into standard 400s. If you don't, we require you to pass us a `ValidationCustomizer` that knows how to turn validation failures into an exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
